### PR TITLE
bugfix: double free service_package.c#354

### DIFF
--- a/service_package.c
+++ b/service_package.c
@@ -351,7 +351,7 @@ package_release(struct package *P) {
 		queue_pop(&P->response, &resp);
 		skynet_free(resp.msg);
 	}
-	if (P->uncomplete.sz >= 0)
+	if (P->uncomplete_sz >= 0)
 		skynet_free(P->uncomplete.msg);
 	queue_exit(&P->request);
 	queue_exit(&P->response);


### PR DESCRIPTION
open skynet-src/malloc_hook.c  #define MEMORY_CHECK can reappear bug.
xmalloc: double free in :00000000
skynet: skynet-src/malloc_hook.c:114: clean_prefix: Assertion `dogtag == MEMORY_ALLOCTAG' failed.